### PR TITLE
RemoveRotationFlags

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1147,6 +1147,21 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			for(int i = 0; i < m_Brush.m_lLayers.size(); i++)
 				m_Brush.m_lLayers[i]->BrushRotate(s_RotationAmount/360.0f*pi*2);
 		}
+
+		TB_Top.VSplitLeft(10.0f, &Button, &TB_Top);
+		TB_Top.VSplitLeft(30.0f, &Button, &TB_Top);
+		static int s_NButton = 0;
+		CLayerTiles *pT = (CLayerTiles *)GetSelectedLayerType(0, LAYERTYPE_TILES);
+		if (pT && (!(pT->m_Game || pT-> m_Front)))
+			pT = 0;
+		if (DoButton_Editor(&s_NButton, "H", pT ? 0 : -1, &Button, 0, "[H] Remove rotation from each non-rotateable tile") || (Input()->KeyPress(KEY_H) && m_Dialog == DIALOG_NONE && m_EditBoxActive == 0))
+		{
+			if (!pT)
+				return;
+			for (int i = 0; i < m_Brush.m_lLayers.size(); i++)
+				m_Brush.m_lLayers[i]->RemoveRotationFlags();
+		}
+
 	}
 
 	// refocus button

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -151,6 +151,7 @@ public:
 	virtual void BrushFlipX() {}
 	virtual void BrushFlipY() {}
 	virtual void BrushRotate(float Amount) {}
+	virtual void RemoveRotationFlags() {}
 
 	virtual void Render() {}
 	virtual int RenderProperties(CUIRect *pToolbox) { return 0; }
@@ -529,6 +530,7 @@ public:
 	virtual void BrushFlipX();
 	virtual void BrushFlipY();
 	virtual void BrushRotate(float Amount);
+	virtual void RemoveRotationFlags();
 
 	virtual void ShowInfo();
 	virtual int RenderProperties(CUIRect *pToolbox);

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -446,6 +446,16 @@ void CLayerTiles::BrushRotate(float Amount)
 	}
 }
 
+void CLayerTiles::RemoveRotationFlags()
+{
+	for (int y = 0; y < m_Height; y++)
+		for (int x = 0; x < m_Width; x++)
+		{
+			auto i = m_pTiles[y*m_Width + x].m_Index;
+			if (i != TILE_STOP && i != TILE_STOPS && i != TILE_CP && i != TILE_CP_F&& i != TILE_THROUGH_DIR)
+				m_pTiles[y*m_Width + x].m_Flags &= ~(TILEFLAG_ROTATE | TILEFLAG_VFLIP | TILEFLAG_HFLIP);
+		}
+}
 void CLayerTiles::Resize(int NewW, int NewH)
 {
 	CTile *pNewData = new CTile[NewW*NewH];


### PR DESCRIPTION
As a mapper I had many troubles when I need to rotate/reflect single part.
Problem - rotating entities, behaviour of which is not depend on the rotation.
Solution - adding new Button ("H") which removes rotate/flip flags from tiles except hardoded ids 60, 61, 64, 65, 67
![normalization](https://cloud.githubusercontent.com/assets/17499770/15015724/3b87abb8-1216-11e6-8171-4c46b9351af2.png)
